### PR TITLE
Backtracking multivariate outliers to original data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,17 @@ Maintainer: Selcuk Korkmaz <selcukorkmaz@gmail.com>
 Depends: R (>= 3.5.0)
 Suggests: BiocStyle, knitr, rmarkdown
 VignetteBuilder: knitr
-Imports: methods, nortest, moments, MASS, plyr,
-        psych, boot, energy, car
+Imports: 
+    methods,
+    nortest,
+    moments,
+    MASS,
+    plyr,
+    psych,
+    boot,
+    energy,
+    car,
+    dplyr
 Collate: mvn.R 
 Description: Performs multivariate normality tests and graphical approaches and
     implements multivariate outlier detection and univariate normality of marginal

--- a/R/mvn.R
+++ b/R/mvn.R
@@ -495,7 +495,10 @@ mvOutlier <- function (data, qqplot = TRUE, alpha = 0.5, tol = 1e-25, method = c
   mah <- mahalanobis(data, center = covr$center, cov = covr$cov,
                      tol = tol)
   d <- mah
-  sortMah <- data.frame(sort(mah, decreasing = TRUE))
+  sortMah <- data.frame(mah)
+  row.names(sortMah) <- row.names(data)
+  sortMah <- dplyr::arrange(sortMah, desc(sortMah))
+  #sortMah <- data.frame(sort(mah, decreasing = TRUE))
   out <- cbind(rownames(sortMah), round(sortMah, 3), NA)
   colnames(out) <- c("Observation", "Mahalanobis Distance",
                      "Outlier")


### PR DESCRIPTION
As mentioned in #8, `MVN::mvn()` currently provides no way to identify multivariate outliers in the original data based on its output.

In this commit `mvOutlier()` is adapted to output the `row.names` of the original data for the outliers in plots and in `mvn()[["multivariateOutliers"]]`:

1. Calculated Mahalanobis distances are stored in the `data.frame` `sortMah` which is not sorted yet
2. `row.names` of `sortMah` are overwritten by `row.names` of the original `data`
3. `sortMah` gets sorted with `dplyr::arrange(desc(sortMah))` which maintains `row.names`
