### PR TITLE
Revamp Shiny UI with modular multi-tab layout

### DIFF
--- a/mvn-shiny-app/app_server.R
+++ b/mvn-shiny-app/app_server.R
@@ -1,6 +1,26 @@
 app_server <- function(input, output, session) {
   data_prep <- mod_data_prep_server("data_prep")
 
+  analysis_settings <- mod_analysis_settings_server("analysis")
+
+  analysis <- mod_results_server(
+    "results",
+    processed_data = data_prep$processed_data,
+    settings = analysis_settings$settings
+  )
+
+  mod_graphs_server(
+    "graphs",
+    processed_data = data_prep$processed_data
+  )
+
+  mod_report_server(
+    "report",
+    processed_data = data_prep$processed_data,
+    analysis_result = analysis$result,
+    settings = analysis_settings$settings
+  )
+
   observeEvent(data_prep$processed_data(), {
     prepared <- data_prep$processed_data()
     if (!is.null(prepared)) {

--- a/mvn-shiny-app/app_ui.R
+++ b/mvn-shiny-app/app_ui.R
@@ -1,11 +1,11 @@
 app_ui <- function(request) {
-  shiny::fluidPage(
-    shiny::titlePanel("MVN Shiny App"),
-    shiny::tabsetPanel(
-      shiny::tabPanel(
-        title = "Data Preparation",
-        mod_data_prep_ui("data_prep")
-      )
-    )
+  bslib::page_navbar(
+    title = "MVN Shiny App",
+    theme = bslib::bs_theme(version = 5, bootswatch = "flatly"),
+    bslib::nav_panel("Data & Preprocessing", mod_data_prep_ui("data_prep")),
+    bslib::nav_panel("Analysis Settings", mod_analysis_settings_ui("analysis")),
+    bslib::nav_panel("Results", mod_results_ui("results")),
+    bslib::nav_panel("Graphs", mod_graphs_ui("graphs")),
+    bslib::nav_panel("Report / Download", mod_report_ui("report"))
   )
 }

--- a/mvn-shiny-app/global.R
+++ b/mvn-shiny-app/global.R
@@ -4,8 +4,16 @@ if (!requireNamespace("shiny", quietly = TRUE)) {
 
 library(shiny)
 
+if (!requireNamespace("bslib", quietly = TRUE)) {
+  stop("The 'bslib' package is required to run this application.")
+}
+
 if (!requireNamespace("MVN", quietly = TRUE)) {
   stop("The 'MVN' package must be installed to run this application.")
+}
+
+if (!requireNamespace("ggplot2", quietly = TRUE)) {
+  stop("The 'ggplot2' package is required to run this application.")
 }
 
 library(MVN)

--- a/mvn-shiny-app/modules/mod_analysis_settings.R
+++ b/mvn-shiny-app/modules/mod_analysis_settings.R
@@ -1,0 +1,122 @@
+mod_analysis_settings_ui <- function(id) {
+  ns <- shiny::NS(id)
+
+  bslib::layout_sidebar(
+    sidebar = bslib::card(
+      bslib::card_header("Configure analysis"),
+      shiny::selectInput(
+        ns("mvn_test"),
+        label = "Multivariate normality test",
+        choices = c(
+          "Mardia (skewness & kurtosis)" = "mardia",
+          "Henze-Zirkler" = "hz",
+          "Henze-Wagner" = "hw",
+          "Royston" = "royston",
+          "Doornik-Hansen" = "doornik_hansen",
+          "Energy" = "energy"
+        ),
+        selected = "hz"
+      ),
+      shiny::selectInput(
+        ns("univariate_test"),
+        label = "Univariate normality test",
+        choices = c(
+          "Anderson-Darling" = "AD",
+          "Shapiro-Wilk" = "SW",
+          "Cramér–von Mises" = "CVM",
+          "Lilliefors" = "Lillie",
+          "Shapiro-Francia" = "SF"
+        ),
+        selected = "AD"
+      ),
+      shiny::selectInput(
+        ns("outlier_method"),
+        label = "Multivariate outliers",
+        choices = c(
+          "None" = "none",
+          "Robust quantile (quan)" = "quan",
+          "Adjusted robust weights (adj)" = "adj"
+        ),
+        selected = "none"
+      ),
+      shiny::checkboxInput(ns("descriptives"), label = "Compute descriptive statistics", value = TRUE),
+      shiny::checkboxInput(ns("bootstrap"), label = "Bootstrap p-values (where available)", value = FALSE),
+      shiny::numericInput(ns("alpha"), label = "Significance level (alpha)", value = 0.05, min = 0.0001, max = 0.25, step = 0.01),
+      shiny::actionButton(ns("apply_settings"), label = "Run analysis", class = "btn-primary")
+    ),
+    bslib::layout_column_wrap(
+      width = 1,
+      bslib::card(
+        bslib::card_header("Current configuration"),
+        shiny::helpText("Adjust options in the sidebar and click Run analysis to update the downstream tabs."),
+        shiny::verbatimTextOutput(ns("settings_summary"))
+      )
+    )
+  )
+}
+
+mod_analysis_settings_server <- function(id) {
+  shiny::moduleServer(
+    id,
+    function(input, output, session) {
+      mvn_labels <- c(
+        mardia = "Mardia (skewness & kurtosis)",
+        hz = "Henze-Zirkler",
+        hw = "Henze-Wagner",
+        royston = "Royston",
+        doornik_hansen = "Doornik-Hansen",
+        energy = "Energy"
+      )
+
+      univariate_labels <- c(
+        AD = "Anderson-Darling",
+        SW = "Shapiro-Wilk",
+        CVM = "Cramér–von Mises",
+        Lillie = "Lilliefors",
+        SF = "Shapiro-Francia"
+      )
+
+      outlier_labels <- c(
+        none = "None",
+        quan = "Robust quantile",
+        adj = "Adjusted robust weights"
+      )
+
+      collect_settings <- function() {
+        alpha_value <- suppressWarnings(as.numeric(input$alpha))
+        if (!is.finite(alpha_value) || alpha_value <= 0) {
+          alpha_value <- 0.05
+        }
+        list(
+          mvn_test = input$mvn_test,
+          test_label = mvn_labels[[input$mvn_test]],
+          univariate_test = input$univariate_test,
+          univariate_label = univariate_labels[[input$univariate_test]],
+          outlier_method = input$outlier_method,
+          outlier_label = outlier_labels[[input$outlier_method]],
+          descriptives = isTRUE(input$descriptives),
+          bootstrap = isTRUE(input$bootstrap),
+          alpha = alpha_value
+        )
+      }
+
+      settings <- shiny::eventReactive(
+        input$apply_settings,
+        collect_settings(),
+        ignoreNULL = FALSE
+      )
+
+      output$settings_summary <- shiny::renderPrint({
+        opts <- settings()
+        cat("Multivariate test:", opts$test_label, "\n")
+        cat("Univariate test:", opts$univariate_label, "\n")
+        cat("Outlier detection:", opts$outlier_label, "\n")
+        cat("Descriptives:", if (isTRUE(opts$descriptives)) "Yes" else "No", "\n")
+        cat("Bootstrap:", if (isTRUE(opts$bootstrap)) "Enabled" else "Disabled", "\n")
+        cat("Alpha:", format(opts$alpha, digits = 3), "\n")
+      })
+
+      list(settings = settings)
+    }
+  )
+}

--- a/mvn-shiny-app/modules/mod_data_prep.R
+++ b/mvn-shiny-app/modules/mod_data_prep.R
@@ -1,12 +1,13 @@
 mod_data_prep_ui <- function(id) {
   ns <- shiny::NS(id)
 
-  shiny::tagList(
-    shiny::sidebarLayout(
-      shiny::sidebarPanel(
+  bslib::layout_sidebar(
+    sidebar = shiny::tagList(
+      bslib::card(
+        bslib::card_header("Data source"),
         shiny::radioButtons(
           ns("data_source"),
-          label = "Data source",
+          label = NULL,
           choices = c("Sample dataset" = "sample", "Upload file" = "upload"),
           selected = "sample"
         ),
@@ -38,11 +39,13 @@ mod_data_prep_ui <- function(id) {
             choices = c("," = ",", ";" = ";", "Tab" = "\t"),
             selected = ","
           )
-        ),
-        shiny::hr(),
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Missing data"),
         shiny::selectInput(
           ns("impute_method"),
-          label = "Missing data handling",
+          label = "Handling method",
           choices = c("None" = "none", "Mean" = "mean", "Median" = "median", "MICE" = "mice"),
           selected = "none"
         ),
@@ -50,8 +53,10 @@ mod_data_prep_ui <- function(id) {
           condition = sprintf("input['%s'] == 'mice'", ns("impute_method")),
           shiny::numericInput(ns("mice_m"), label = "Number of imputations (m)", value = 5, min = 1, step = 1),
           shiny::numericInput(ns("mice_seed"), label = "Random seed", value = 123, min = 1, step = 1)
-        ),
-        shiny::hr(),
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Transformations"),
         shiny::selectInput(
           ns("transform_family"),
           label = "Power transformation",
@@ -72,19 +77,27 @@ mod_data_prep_ui <- function(id) {
             inline = TRUE,
             selected = "optimal"
           )
-        ),
+        )
+      ),
+      bslib::card(
+        bslib::card_header("Standardization"),
         shiny::checkboxInput(
           ns("standardize"),
           label = "Center and scale numeric columns",
           value = FALSE
         )
-      ),
-      shiny::mainPanel(
-        shiny::h4("Data summary"),
+      )
+    ),
+    bslib::layout_column_wrap(
+      width = 1/2,
+      bslib::card(
+        bslib::card_header("Data summary"),
         shiny::verbatimTextOutput(ns("data_info")),
         shiny::uiOutput(ns("excluded_ui")),
-        shiny::tableOutput(ns("missing_overview")),
-        shiny::h4("Preview of prepared data"),
+        shiny::tableOutput(ns("missing_overview"))
+      ),
+      bslib::card(
+        bslib::card_header("Prepared data preview"),
         shiny::tableOutput(ns("data_preview")),
         shiny::uiOutput(ns("lambda_header")),
         shiny::tableOutput(ns("lambda_table"))

--- a/mvn-shiny-app/modules/mod_graphs.R
+++ b/mvn-shiny-app/modules/mod_graphs.R
@@ -1,0 +1,107 @@
+mod_graphs_ui <- function(id) {
+  ns <- shiny::NS(id)
+
+  bslib::layout_sidebar(
+    sidebar = bslib::card(
+      bslib::card_header("Plot controls"),
+      shiny::selectInput(
+        ns("plot_type"),
+        label = "Plot type",
+        choices = c(
+          "Pairs plot" = "pairs",
+          "Correlation heatmap" = "correlation",
+          "Q-Q plot" = "qq",
+          "Density" = "density"
+        ),
+        selected = "pairs"
+      ),
+      shiny::uiOutput(ns("variable_ui"))
+    ),
+    bslib::card(
+      bslib::card_header("Visualization"),
+      shiny::plotOutput(ns("plot"), height = "520px")
+    )
+  )
+}
+
+mod_graphs_server <- function(id, processed_data) {
+  stopifnot(is.function(processed_data))
+
+  shiny::moduleServer(
+    id,
+    function(input, output, session) {
+      observeEvent(processed_data(), {
+        data <- processed_data()
+        if (is.null(data)) {
+          return()
+        }
+        vars <- names(data)
+        shiny::updateSelectInput(session, "plot_variable", choices = vars)
+      }, ignoreNULL = FALSE)
+
+      output$variable_ui <- shiny::renderUI({
+        if (input$plot_type %in% c("qq", "density")) {
+          data <- processed_data()
+          if (is.null(data)) {
+            return(NULL)
+          }
+          shiny::selectInput(
+            session$ns("plot_variable"),
+            label = "Variable",
+            choices = names(data)
+          )
+        } else {
+          NULL
+        }
+      })
+
+      output$plot <- shiny::renderPlot({
+        df <- processed_data()
+        shiny::req(df)
+        plot_type <- input$plot_type
+
+        if (plot_type == "pairs") {
+          shiny::validate(shiny::need(ncol(df) >= 2, "At least two variables are required for a pairs plot."))
+          pairs(df, main = "Pairs plot of prepared data", pch = 19, col = grDevices::adjustcolor("#0d6efd", alpha.f = 0.4))
+          return(invisible(NULL))
+        }
+
+        if (plot_type == "correlation") {
+          shiny::validate(shiny::need(ncol(df) >= 2, "At least two variables are required to compute correlations."))
+          corr <- stats::cor(df, use = "pairwise.complete.obs")
+          corr_df <- data.frame(
+            Var1 = rep(colnames(corr), times = nrow(corr)),
+            Var2 = rep(rownames(corr), each = ncol(corr)),
+            value = as.vector(corr),
+            stringsAsFactors = FALSE
+          )
+          plot_obj <- ggplot2::ggplot(corr_df, ggplot2::aes(x = Var1, y = Var2, fill = value)) +
+            ggplot2::geom_tile(color = "white") +
+            ggplot2::scale_fill_gradient2(limits = c(-1, 1), low = "#dc3545", mid = "#f8f9fa", high = "#198754") +
+            ggplot2::labs(fill = "Correlation", x = NULL, y = NULL) +
+            ggplot2::coord_fixed() +
+            ggplot2::theme_minimal()
+          return(plot_obj)
+        }
+
+        var <- input$plot_variable
+        shiny::req(var)
+        shiny::validate(shiny::need(var %in% names(df), "Select a variable to continue."))
+        plot_df <- data.frame(value = df[[var]])
+
+        if (plot_type == "qq") {
+          ggplot2::ggplot(plot_df, ggplot2::aes(sample = value)) +
+            ggplot2::stat_qq(color = "#0d6efd") +
+            ggplot2::stat_qq_line(color = "#6c757d") +
+            ggplot2::labs(title = paste("Q-Q plot for", var), x = "Theoretical quantiles", y = "Sample quantiles") +
+            ggplot2::theme_minimal()
+        } else if (plot_type == "density") {
+          ggplot2::ggplot(plot_df, ggplot2::aes(x = value)) +
+            ggplot2::geom_density(fill = "#0d6efd", alpha = 0.4, color = "#0d6efd") +
+            ggplot2::labs(title = paste("Density for", var), x = var, y = "Density") +
+            ggplot2::theme_minimal()
+        }
+      })
+    }
+  )
+}

--- a/mvn-shiny-app/modules/mod_report.R
+++ b/mvn-shiny-app/modules/mod_report.R
@@ -1,0 +1,120 @@
+mod_report_ui <- function(id) {
+  ns <- shiny::NS(id)
+
+  bslib::layout_sidebar(
+    sidebar = bslib::card(
+      bslib::card_header("Export"),
+      shiny::textInput(ns("base_name"), label = "Base file name", value = "mvn_analysis"),
+      shiny::downloadButton(ns("download_data"), label = "Prepared data (CSV)", class = "btn-primary"),
+      shiny::downloadButton(ns("download_results"), label = "Analysis object (RDS)")
+    ),
+    bslib::layout_column_wrap(
+      width = 1,
+      bslib::card(
+        bslib::card_header("Analysis snapshot"),
+        shiny::uiOutput(ns("report_summary"))
+      ),
+      bslib::card(
+        bslib::card_header("Multivariate test table"),
+        shiny::tableOutput(ns("report_table"))
+      )
+    )
+  )
+}
+
+mod_report_server <- function(id, processed_data, analysis_result, settings) {
+  stopifnot(is.function(processed_data), is.function(analysis_result), is.function(settings))
+
+  shiny::moduleServer(
+    id,
+    function(input, output, session) {
+      base_name <- shiny::reactive({
+        name <- input$base_name
+        if (is.null(name) || !nzchar(trimws(name))) {
+          return("mvn_analysis")
+        }
+        gsub("\\s+", "_", trimws(name))
+      })
+
+      output$report_summary <- shiny::renderUI({
+        data <- processed_data()
+        res <- analysis_result()
+        opts <- settings()
+
+        if (is.null(data) || is.null(res) || is.null(opts)) {
+          return(shiny::div(class = "text-muted", "Run the analysis to generate a report preview."))
+        }
+
+        sample_n <- nrow(data)
+        sample_p <- ncol(data)
+        test_name <- opts$test_label
+        if (is.null(test_name) || is.na(test_name)) {
+          test_name <- opts$mvn_test
+        }
+
+        tbl <- res$multivariate_normality
+        if (!is.null(tbl)) {
+          p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(tbl))
+          p_val <- if (length(p_col) > 0) suppressWarnings(as.numeric(tbl[[p_col[1]]][1])) else NA_real_
+        } else {
+          p_val <- NA_real_
+        }
+
+        shiny::tagList(
+          shiny::p(
+            sprintf(
+              "Prepared dataset contains %d observations and %d numeric variables.",
+              sample_n,
+              sample_p
+            )
+          ),
+          shiny::p(
+            sprintf(
+              "Latest multivariate normality test: %s (alpha = %s).",
+              test_name,
+              format(opts$alpha, digits = 3)
+            )
+          ),
+          if (isTRUE(is.finite(p_val))) {
+            shiny::p(sprintf("Reported p-value: %s", formatC(p_val, digits = 3, format = "g")))
+          },
+          if (isTRUE(opts$descriptives)) {
+            shiny::p("Descriptive statistics were included in the analysis output.")
+          } else {
+            shiny::p("Descriptive statistics were skipped to streamline computation.")
+          }
+        )
+      })
+
+      output$report_table <- shiny::renderTable({
+        res <- analysis_result()
+        shiny::req(res)
+        tbl <- res$multivariate_normality
+        shiny::req(tbl)
+        as.data.frame(tbl)
+      }, rownames = FALSE)
+
+      output$download_data <- shiny::downloadHandler(
+        filename = function() {
+          paste0(base_name(), "_data.csv")
+        },
+        content = function(file) {
+          data <- processed_data()
+          shiny::req(data)
+          utils::write.csv(data, file, row.names = FALSE)
+        }
+      )
+
+      output$download_results <- shiny::downloadHandler(
+        filename = function() {
+          paste0(base_name(), "_analysis.rds")
+        },
+        content = function(file) {
+          res <- analysis_result()
+          shiny::req(res)
+          saveRDS(res, file)
+        }
+      )
+    }
+  )
+}

--- a/mvn-shiny-app/modules/mod_results.R
+++ b/mvn-shiny-app/modules/mod_results.R
@@ -1,0 +1,131 @@
+mod_results_ui <- function(id) {
+  ns <- shiny::NS(id)
+
+  bslib::layout_column_wrap(
+    width = 1/2,
+    bslib::card(
+      bslib::card_header("Multivariate normality"),
+      shiny::uiOutput(ns("results_message")),
+      shiny::tableOutput(ns("test_table"))
+    ),
+    bslib::card(
+      bslib::card_header("Descriptive statistics"),
+      shiny::tableOutput(ns("descriptives_table"))
+    ),
+    bslib::card(
+      bslib::card_header("Analysis details"),
+      shiny::verbatimTextOutput(ns("analysis_summary"))
+    )
+  )
+}
+
+mod_results_server <- function(id, processed_data, settings) {
+  stopifnot(is.function(processed_data), is.function(settings))
+
+  shiny::moduleServer(
+    id,
+    function(input, output, session) {
+      analysis_result <- shiny::reactive({
+        df <- processed_data()
+        opts <- settings()
+        shiny::req(df, opts)
+
+        df <- as.data.frame(df)
+        if (ncol(df) < 2) {
+          shiny::showNotification("At least two numeric variables are required for multivariate analysis.", type = "warning")
+          return(NULL)
+        }
+
+        tryCatch({
+          MVN::mvn(
+            data = df,
+            mvn_test = opts$mvn_test,
+            univariate_test = opts$univariate_test,
+            multivariate_outlier_method = opts$outlier_method,
+            descriptives = isTRUE(opts$descriptives),
+            bootstrap = isTRUE(opts$bootstrap),
+            alpha = opts$alpha,
+            tidy = TRUE
+          )
+        }, error = function(e) {
+          shiny::showNotification(paste("Analysis failed:", e$message), type = "error")
+          NULL
+        })
+      })
+
+      output$results_message <- shiny::renderUI({
+        res <- analysis_result()
+        if (is.null(res)) {
+          return(shiny::div(class = "text-muted", "Run the analysis to view results."))
+        }
+
+        opts <- settings()
+        data <- processed_data()
+        shiny::req(opts, data)
+
+        sample_n <- nrow(data)
+        sample_p <- ncol(data)
+        test_name <- opts$test_label
+        if (is.null(test_name) || is.na(test_name)) {
+          test_name <- opts$mvn_test
+        }
+        alpha <- opts$alpha
+
+        tbl <- res$multivariate_normality
+        if (is.null(tbl)) {
+          p_val <- NA_real_
+        } else {
+          p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(tbl))
+          if (length(p_col) > 0) {
+            p_val <- suppressWarnings(as.numeric(tbl[[p_col[1]]][1]))
+          } else {
+            p_val <- NA_real_
+          }
+        }
+
+        base_message <- sprintf(
+          "Analyzed %d observations across %d variables using the %s test.",
+          sample_n,
+          sample_p,
+          test_name
+        )
+
+        if (isTRUE(is.finite(p_val))) {
+          detail <- paste("Reported p-value:", formatC(p_val, digits = 3, format = "g"))
+          alert_class <- if (p_val < alpha) "alert-warning" else "alert-success"
+          shiny::div(class = paste("alert", alert_class), base_message, detail)
+        } else {
+          shiny::div(class = "alert alert-info", base_message, "Review the table below for details.")
+        }
+      })
+
+      output$test_table <- shiny::renderTable({
+        res <- analysis_result()
+        shiny::req(res)
+        tbl <- res$multivariate_normality
+        shiny::req(tbl)
+        as.data.frame(tbl)
+      }, rownames = FALSE)
+
+      output$descriptives_table <- shiny::renderTable({
+        res <- analysis_result()
+        opts <- settings()
+        shiny::req(res, opts)
+        if (!isTRUE(opts$descriptives)) {
+          shiny::validate(shiny::need(FALSE, "Enable descriptive statistics in the Analysis Settings tab to view this table."))
+        }
+        tbl <- res$descriptives
+        shiny::req(tbl)
+        utils::head(as.data.frame(tbl), n = 12)
+      }, rownames = FALSE)
+
+      output$analysis_summary <- shiny::renderPrint({
+        res <- analysis_result()
+        shiny::req(res)
+        MVN::summary(res, select = "mvn")
+      })
+
+      list(result = analysis_result)
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- wrap the MVN app UI in a bslib-themed navbar with dedicated Data, Settings, Results, Graphs, and Report tabs
- refresh the data preparation module with card-based controls that match the modern layout
- add analysis, results, visualization, and reporting modules that consume the prepared data and user-configured options

## Testing
- Not run (R interpreter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d10a41ba0c832ab4d86ea8ff377917