### PR TITLE
Enhance analysis controls and reactive result handling

### DIFF
--- a/mvn-shiny-app/app_server.R
+++ b/mvn-shiny-app/app_server.R
@@ -1,7 +1,10 @@
 app_server <- function(input, output, session) {
   data_prep <- mod_data_prep_server("data_prep")
 
-  analysis_settings <- mod_analysis_settings_server("analysis")
+  analysis_settings <- mod_analysis_settings_server(
+    "analysis",
+    processed_data = data_prep$processed_data
+  )
 
   analysis <- mod_results_server(
     "results",

--- a/mvn-shiny-app/modules/mod_report.R
+++ b/mvn-shiny-app/modules/mod_report.R
@@ -87,6 +87,15 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
               format(opts$alpha, digits = 3)
             )
           ),
+          if (isTRUE(opts$bootstrap) || identical(opts$mvn_test, "energy")) {
+            shiny::p(
+              sprintf(
+                "Bootstrap settings: B = %d, cores = %d.",
+                opts$B,
+                opts$cores
+              )
+            )
+          },
           if (isTRUE(is.finite(p_val))) {
             shiny::p(sprintf("Reported p-value: %s", formatC(p_val, digits = 3, format = "g")))
           },


### PR DESCRIPTION
## Summary
- add bootstrap replicate/core controls and high-dimensional warnings to the analysis settings module
- cache MVN results in a reactiveVal and surface rerun guidance while passing bootstrap options through to MVN::mvn
- propagate the new settings to the server wiring and report snapshot so bootstrap configuration is reflected downstream

## Testing
- `Rscript -e "pkgload::load_all(); cat('Package load successful\n')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d114d702ec832ab1aacd0f22f39e72