### PR TITLE
Enhance MVN app results tables and exports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,10 @@ Imports:
     energy,
     plotly,
     mice
+Suggests:
+    DT,
+    jsonlite,
+    yaml
 Collate:
     'mvn.R'
     'mardia.R'

--- a/mvn-shiny-app/global.R
+++ b/mvn-shiny-app/global.R
@@ -16,6 +16,18 @@ if (!requireNamespace("ggplot2", quietly = TRUE)) {
   stop("The 'ggplot2' package is required to run this application.")
 }
 
+if (!requireNamespace("DT", quietly = TRUE)) {
+  stop("The 'DT' package is required to display interactive result tables.")
+}
+
+if (!requireNamespace("jsonlite", quietly = TRUE)) {
+  stop("The 'jsonlite' package is required to export analysis parameters as JSON.")
+}
+
+if (!requireNamespace("yaml", quietly = TRUE)) {
+  stop("The 'yaml' package is required to export analysis parameters as YAML.")
+}
+
 library(MVN)
 
 modules_dir <- file.path(getwd(), "modules")

--- a/mvn-shiny-app/modules/mod_report.R
+++ b/mvn-shiny-app/modules/mod_report.R
@@ -5,8 +5,14 @@ mod_report_ui <- function(id) {
     sidebar = bslib::card(
       bslib::card_header("Export"),
       shiny::textInput(ns("base_name"), label = "Base file name", value = "mvn_analysis"),
-      shiny::downloadButton(ns("download_data"), label = "Prepared data (CSV)", class = "btn-primary"),
-      shiny::downloadButton(ns("download_results"), label = "Analysis object (RDS)")
+      shiny::div(
+        class = "d-grid gap-2",
+        shiny::downloadButton(ns("download_data"), label = "Prepared data (CSV)", class = "btn-primary"),
+        shiny::downloadButton(ns("download_results"), label = "Analysis object (RDS)", class = "btn-outline-primary"),
+        shiny::downloadButton(ns("download_results_csv"), label = "Analysis tables (CSV)", class = "btn-outline-secondary"),
+        shiny::downloadButton(ns("download_parameters_yaml"), label = "Parameters (YAML)", class = "btn-outline-secondary"),
+        shiny::downloadButton(ns("download_parameters_json"), label = "Parameters (JSON)", class = "btn-outline-secondary")
+      )
     ),
     bslib::layout_column_wrap(
       width = 1,
@@ -38,6 +44,145 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
         gsub("\\s+", "_", trimws(name))
       })
 
+      extract_p_value <- function(tbl) {
+        if (is.null(tbl)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        df <- as.data.frame(tbl)
+        if (!nrow(df)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(df))
+        if (!length(p_col)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        raw_value <- df[[p_col[1]]][1]
+        if (length(raw_value) == 0) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        display <- if (is.numeric(raw_value)) {
+          formatC(raw_value, digits = 3, format = "g")
+        } else {
+          as.character(raw_value)
+        }
+        numeric_value <- suppressWarnings(as.numeric(raw_value))
+        if (!is.finite(numeric_value) && is.character(raw_value)) {
+          if (grepl("^\\s*<", raw_value)) {
+            numeric_value <- suppressWarnings(as.numeric(sub("^\\s*<\\s*", "", raw_value)))
+          } else if (grepl("^\\s*>", raw_value)) {
+            numeric_value <- suppressWarnings(as.numeric(sub("^\\s*>\\s*", "", raw_value)))
+          }
+        }
+        list(
+          display = if (is.null(display) || !nzchar(display)) "\u2014" else display,
+          numeric = numeric_value
+        )
+      }
+
+      build_analysis_csv <- function(res) {
+        tables <- list(
+          multivariate_tests = res$multivariate_normality,
+          univariate_tests = res$univariate_normality,
+          descriptives = res$descriptives,
+          multivariate_outliers = res$multivariate_outliers,
+          cleaned_data = res$new_data
+        )
+        tables <- tables[!vapply(tables, is.null, logical(1))]
+        if (!length(tables)) {
+          return(NULL)
+        }
+        combined <- lapply(names(tables), function(name) {
+          df <- as.data.frame(tables[[name]])
+          if (!nrow(df)) {
+            return(NULL)
+          }
+          rows <- seq_len(nrow(df))
+          columns <- names(df)
+          column_frames <- lapply(columns, function(col) {
+            values <- df[[col]]
+            data.frame(
+              table = name,
+              row = rows,
+              column = col,
+              value = as.character(values),
+              stringsAsFactors = FALSE
+            )
+          })
+          do.call(rbind, column_frames)
+        })
+        combined <- Filter(Negate(is.null), combined)
+        if (!length(combined)) {
+          return(NULL)
+        }
+        result <- do.call(rbind, combined)
+        rownames(result) <- NULL
+        result
+      }
+
+      collect_parameters <- function() {
+        opts <- settings()
+        params <- list()
+        if (!is.null(opts)) {
+          params$tests <- list(
+            mvn_test = opts$mvn_test,
+            mvn_test_label = opts$test_label,
+            univariate_test = opts$univariate_test,
+            univariate_test_label = opts$univariate_label,
+            outlier_method = opts$outlier_method,
+            outlier_method_label = opts$outlier_label
+          )
+          params$significance <- list(alpha = opts$alpha)
+          params$descriptives <- isTRUE(opts$descriptives)
+          params$bootstrap <- list(
+            enabled = isTRUE(opts$bootstrap),
+            replicates = opts$B,
+            cores = opts$cores
+          )
+        }
+
+        res <- analysis_result()
+        if (!is.null(res)) {
+          dataset_info <- list()
+          data <- res$data
+          if (!is.null(data)) {
+            data <- as.data.frame(data)
+            group <- res$subset
+            if (is.null(group) || !nzchar(group) || !(group %in% names(data))) {
+              group <- NULL
+            }
+            numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
+            if (!is.null(group)) {
+              numeric_cols <- setdiff(numeric_cols, group)
+            }
+            dataset_info$observations <- nrow(data)
+            dataset_info$numeric_variables <- length(numeric_cols)
+            if (!is.null(group)) {
+              dataset_info$grouping_variable <- group
+              dataset_info$group_levels <- length(unique(data[[group]][!is.na(data[[group]])]))
+            }
+          }
+          outlier_tbl <- res$multivariate_outliers
+          dataset_info$outliers_flagged <- if (is.null(outlier_tbl)) 0L else nrow(as.data.frame(outlier_tbl))
+          if (!is.null(res$new_data)) {
+            dataset_info$cleaned_observations <- nrow(as.data.frame(res$new_data))
+          }
+          if (length(dataset_info)) {
+            params$dataset <- dataset_info
+          }
+          if (!is.null(opts)) {
+            p_info <- extract_p_value(res$multivariate_normality)
+            params$decision <- list(
+              alpha = opts$alpha,
+              p_value = p_info$numeric,
+              p_value_display = p_info$display,
+              normal = if (!is.null(p_info$numeric) && is.finite(p_info$numeric)) p_info$numeric >= opts$alpha else NULL
+            )
+          }
+        }
+
+        params
+      }
+
       output$report_summary <- shiny::renderUI({
         data <- processed_data()
         res <- analysis_result()
@@ -47,46 +192,74 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
           return(shiny::div(class = "text-muted", "Run the analysis to generate a report preview."))
         }
 
+        data <- as.data.frame(data)
+        numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
         sample_n <- nrow(data)
-        sample_p <- ncol(data)
-        subset_var <- res$subset
+        sample_p <- length(numeric_cols)
+
+        analysis_df <- res$data
+        if (!is.null(analysis_df)) {
+          analysis_df <- as.data.frame(analysis_df)
+        } else {
+          analysis_df <- data
+        }
+
+        group <- res$subset
+        if (is.null(group) || !nzchar(group) || !(group %in% names(analysis_df))) {
+          group <- NULL
+        }
+
         test_name <- opts$test_label
         if (is.null(test_name) || is.na(test_name)) {
           test_name <- opts$mvn_test
         }
 
-        tbl <- res$multivariate_normality
-        if (!is.null(tbl)) {
-          p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(tbl))
-          p_val <- if (length(p_col) > 0) suppressWarnings(as.numeric(tbl[[p_col[1]]][1])) else NA_real_
-        } else {
-          p_val <- NA_real_
-        }
+        p_info <- extract_p_value(res$multivariate_normality)
+        outlier_tbl <- res$multivariate_outliers
+        outlier_count <- if (is.null(outlier_tbl)) 0L else nrow(as.data.frame(outlier_tbl))
+        cleaned_rows <- if (!is.null(res$new_data)) nrow(as.data.frame(res$new_data)) else NULL
 
         shiny::tagList(
           shiny::p(
             sprintf(
-              "Prepared dataset contains %d observations and %d numeric variables.",
-              sample_n,
-              sample_p
+              "Prepared dataset contains %s observations and %s numeric variables.",
+              format(sample_n, big.mark = ",", trim = TRUE),
+              format(sample_p, big.mark = ",", trim = TRUE)
             )
           ),
-          if (!is.null(subset_var) && nzchar(subset_var) && !is.null(res$data) && subset_var %in% names(res$data)) {
+          if (!is.null(group)) {
             shiny::p(
               sprintf(
                 "Grouping variable: %s (%d levels).",
-                subset_var,
-                length(unique(res$data[[subset_var]][!is.na(res$data[[subset_var]])]))
+                group,
+                length(unique(analysis_df[[group]][!is.na(analysis_df[[group]])]))
               )
             )
           },
           shiny::p(
             sprintf(
-              "Latest multivariate normality test: %s (alpha = %s).",
+              "Latest multivariate normality test: %s (\u03b1 = %s).",
               test_name,
-              format(opts$alpha, digits = 3)
+              format(opts$alpha, digits = 3, trim = TRUE)
             )
           ),
+          if (!is.null(opts$outlier_label)) {
+            shiny::p(
+              sprintf(
+                "Outlier method: %s (%d flagged).",
+                opts$outlier_label,
+                outlier_count
+              )
+            )
+          },
+          if (!is.null(cleaned_rows)) {
+            shiny::p(
+              sprintf(
+                "Cleaned dataset contains %s observations after excluding flagged outliers.",
+                format(cleaned_rows, big.mark = ",", trim = TRUE)
+              )
+            )
+          },
           if (isTRUE(opts$bootstrap) || identical(opts$mvn_test, "energy")) {
             shiny::p(
               sprintf(
@@ -96,8 +269,8 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
               )
             )
           },
-          if (isTRUE(is.finite(p_val))) {
-            shiny::p(sprintf("Reported p-value: %s", formatC(p_val, digits = 3, format = "g")))
+          if (!identical(p_info$display, "\u2014")) {
+            shiny::p(sprintf("Reported p-value: %s", p_info$display))
           },
           if (isTRUE(opts$descriptives)) {
             shiny::p("Descriptive statistics were included in the analysis output.")
@@ -134,6 +307,52 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
           res <- analysis_result()
           shiny::req(res)
           saveRDS(res, file)
+        }
+      )
+
+      output$download_results_csv <- shiny::downloadHandler(
+        filename = function() {
+          paste0(base_name(), "_analysis_tables.csv")
+        },
+        content = function(file) {
+          res <- analysis_result()
+          shiny::req(res)
+          csv_data <- build_analysis_csv(res)
+          if (is.null(csv_data) || !nrow(csv_data)) {
+            utils::write.csv(
+              data.frame(message = "No tabular results were produced for this analysis.", stringsAsFactors = FALSE),
+              file,
+              row.names = FALSE
+            )
+          } else {
+            utils::write.csv(csv_data, file, row.names = FALSE)
+          }
+        }
+      )
+
+      output$download_parameters_yaml <- shiny::downloadHandler(
+        filename = function() {
+          paste0(base_name(), "_parameters.yaml")
+        },
+        content = function(file) {
+          params <- collect_parameters()
+          if (is.null(params) || !length(params)) {
+            params <- list(message = "No analysis parameters are available.")
+          }
+          yaml::write_yaml(params, file)
+        }
+      )
+
+      output$download_parameters_json <- shiny::downloadHandler(
+        filename = function() {
+          paste0(base_name(), "_parameters.json")
+        },
+        content = function(file) {
+          params <- collect_parameters()
+          if (is.null(params) || !length(params)) {
+            params <- list(message = "No analysis parameters are available.")
+          }
+          jsonlite::write_json(params, file, pretty = TRUE, auto_unbox = TRUE, null = "null")
         }
       )
     }

--- a/mvn-shiny-app/modules/mod_results.R
+++ b/mvn-shiny-app/modules/mod_results.R
@@ -2,15 +2,44 @@ mod_results_ui <- function(id) {
   ns <- shiny::NS(id)
 
   bslib::layout_column_wrap(
-    width = 1/2,
-    bslib::card(
-      bslib::card_header("Multivariate normality"),
-      shiny::uiOutput(ns("results_message")),
-      shiny::tableOutput(ns("test_table"))
+    width = 1,
+    bslib::layout_column_wrap(
+      width = 1/5,
+      bslib::value_box(
+        title = "Observations",
+        value = shiny::textOutput(ns("summary_n"), inline = TRUE)
+      ),
+      bslib::value_box(
+        title = "Variables",
+        value = shiny::textOutput(ns("summary_p"), inline = TRUE)
+      ),
+      bslib::value_box(
+        title = "MVN test",
+        value = shiny::textOutput(ns("summary_test"), inline = TRUE)
+      ),
+      bslib::value_box(
+        title = "p-value",
+        value = shiny::textOutput(ns("summary_pvalue"), inline = TRUE)
+      ),
+      bslib::value_box(
+        title = "Normality",
+        value = shiny::uiOutput(ns("summary_decision"))
+      )
     ),
     bslib::card(
-      bslib::card_header("Descriptive statistics"),
-      shiny::tableOutput(ns("descriptives_table"))
+      bslib::card_header("Multivariate normality"),
+      shiny::uiOutput(ns("results_message"))
+    ),
+    bslib::card(
+      bslib::card_header("Detailed tables"),
+      shiny::tabsetPanel(
+        type = "pills",
+        shiny::tabPanel("Multivariate tests", DT::dataTableOutput(ns("multivariate_table"))),
+        shiny::tabPanel("Univariate tests", DT::dataTableOutput(ns("univariate_table"))),
+        shiny::tabPanel("Descriptive statistics", DT::dataTableOutput(ns("descriptives_table"))),
+        shiny::tabPanel("Outliers", DT::dataTableOutput(ns("outliers_table"))),
+        shiny::tabPanel("Cleaned data", DT::dataTableOutput(ns("clean_data_table")))
+      )
     ),
     bslib::card(
       bslib::card_header("Analysis details"),
@@ -103,6 +132,7 @@ mod_results_server <- function(id, processed_data, settings, analysis_data = NUL
             alpha = opts$alpha,
             B = opts$B,
             cores = opts$cores,
+            show_new_data = TRUE,
             tidy = TRUE
           )
         }, error = function(e) {
@@ -139,6 +169,134 @@ mod_results_server <- function(id, processed_data, settings, analysis_data = NUL
         analysis_needs_run(TRUE)
       }, ignoreNULL = FALSE)
 
+      extract_p_value <- function(tbl) {
+        if (is.null(tbl)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        df <- as.data.frame(tbl)
+        if (!nrow(df)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(df))
+        if (!length(p_col)) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        raw_value <- df[[p_col[1]]][1]
+        if (length(raw_value) == 0) {
+          return(list(display = "\u2014", numeric = NA_real_))
+        }
+        display <- if (is.numeric(raw_value)) {
+          formatC(raw_value, digits = 3, format = "g")
+        } else {
+          as.character(raw_value)
+        }
+        numeric_value <- suppressWarnings(as.numeric(raw_value))
+        if (!is.finite(numeric_value) && is.character(raw_value)) {
+          if (grepl("^\\s*<", raw_value)) {
+            numeric_value <- suppressWarnings(as.numeric(sub("^\\s*<\\s*", "", raw_value)))
+          } else if (grepl("^\\s*>", raw_value)) {
+            numeric_value <- suppressWarnings(as.numeric(sub("^\\s*>\\s*", "", raw_value)))
+          }
+        }
+        list(
+          display = if (is.null(display) || !nzchar(display)) "\u2014" else display,
+          numeric = numeric_value
+        )
+      }
+
+      summary_info <- shiny::reactive({
+        res <- analysis_result()
+        opts <- settings()
+        if (is.null(res) || is.null(opts)) {
+          return(NULL)
+        }
+        data <- res$data
+        if (is.null(data)) {
+          return(NULL)
+        }
+        data <- as.data.frame(data)
+        group <- res$subset
+        if (is.null(group) || !nzchar(group) || !(group %in% names(data))) {
+          group <- NULL
+        }
+        numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
+        if (!is.null(group)) {
+          numeric_cols <- setdiff(numeric_cols, group)
+        }
+        p_info <- extract_p_value(res$multivariate_normality)
+        outlier_tbl <- res$multivariate_outliers
+        outlier_count <- if (is.null(outlier_tbl)) 0L else nrow(as.data.frame(outlier_tbl))
+        test_name <- opts$test_label
+        if (is.null(test_name) || is.na(test_name)) {
+          test_name <- opts$mvn_test
+        }
+        list(
+          n = nrow(data),
+          p = length(numeric_cols),
+          group = group,
+          group_levels = if (!is.null(group)) length(unique(data[[group]][!is.na(data[[group]])])) else NULL,
+          test_label = test_name,
+          alpha = opts$alpha,
+          p_display = p_info$display,
+          p_value = p_info$numeric,
+          outlier_label = opts$outlier_label,
+          outlier_count = outlier_count,
+          cleaned_available = !is.null(res$new_data)
+        )
+      })
+
+      output$summary_n <- shiny::renderText({
+        info <- summary_info()
+        if (is.null(info)) {
+          return("\u2014")
+        }
+        format(info$n, big.mark = ",", trim = TRUE)
+      })
+
+      output$summary_p <- shiny::renderText({
+        info <- summary_info()
+        if (is.null(info)) {
+          return("\u2014")
+        }
+        format(info$p, big.mark = ",", trim = TRUE)
+      })
+
+      output$summary_test <- shiny::renderText({
+        info <- summary_info()
+        if (is.null(info)) {
+          return("\u2014")
+        }
+        sprintf("%s (\u03b1 = %s)", info$test_label, format(info$alpha, digits = 3, trim = TRUE))
+      })
+
+      output$summary_pvalue <- shiny::renderText({
+        info <- summary_info()
+        if (is.null(info)) {
+          return("\u2014")
+        }
+        info$p_display
+      })
+
+      output$summary_decision <- shiny::renderUI({
+        info <- summary_info()
+        if (is.null(info)) {
+          return(shiny::tags$span(class = "badge bg-secondary", "Awaiting analysis"))
+        }
+        if (!is.null(info$p_value) && is.finite(info$p_value)) {
+          if (info$p_value < info$alpha) {
+            badge_class <- "badge bg-danger"
+            badge_text <- "Not normal"
+          } else {
+            badge_class <- "badge bg-success"
+            badge_text <- "Normal"
+          }
+        } else {
+          badge_class <- "badge bg-info text-dark"
+          badge_text <- "Review details"
+        }
+        shiny::tags$span(class = badge_class, badge_text)
+      })
+
       output$results_message <- shiny::renderUI({
         res <- analysis_result()
         if (is.null(res)) {
@@ -151,72 +309,102 @@ mod_results_server <- function(id, processed_data, settings, analysis_data = NUL
           return(shiny::div(class = "text-muted", "Run the analysis to view results."))
         }
 
-        opts <- settings()
-        data <- data_for_analysis()
-        shiny::req(opts, data)
-
-        data <- as.data.frame(data)
-        group <- subset_var()
-        if (!is.null(group) && !nzchar(group)) {
-          group <- NULL
-        }
-        numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
-        if (!is.null(group)) {
-          numeric_cols <- setdiff(numeric_cols, group)
-        }
-        sample_n <- nrow(data)
-        sample_p <- length(numeric_cols)
-        test_name <- opts$test_label
-        if (is.null(test_name) || is.na(test_name)) {
-          test_name <- opts$mvn_test
-        }
-        alpha <- opts$alpha
-
-        tbl <- res$multivariate_normality
-        if (is.null(tbl)) {
-          p_val <- NA_real_
-        } else {
-          p_col <- intersect(c("p.value", "p_value", "pvalue", "p.value.skew"), names(tbl))
-          if (length(p_col) > 0) {
-            p_val <- suppressWarnings(as.numeric(tbl[[p_col[1]]][1]))
-          } else {
-            p_val <- NA_real_
-          }
+        info <- summary_info()
+        if (is.null(info)) {
+          return(shiny::div(class = "alert alert-info", "Run the analysis to view results."))
         }
 
-        base_message <- sprintf(
-          "Analyzed %d observations across %d variables using the %s test.",
-          sample_n,
-          sample_p,
-          test_name
+        base_text <- sprintf(
+          "Analyzed %s observations across %s variables using the %s test.",
+          format(info$n, big.mark = ",", trim = TRUE),
+          format(info$p, big.mark = ",", trim = TRUE),
+          info$test_label
         )
 
-        if (!is.null(group) && group %in% names(data)) {
-          group_levels <- length(unique(data[[group]][!is.na(data[[group]])]))
-          base_message <- paste0(
-            base_message,
-            sprintf(" Grouping variable: %s (%d levels).", group, group_levels)
+        details <- character(0)
+        if (!is.null(info$group)) {
+          details <- c(
+            details,
+            sprintf(
+              "Grouping variable: %s (%d levels).",
+              info$group,
+              info$group_levels
+            )
+          )
+        }
+        if (!is.null(info$outlier_label)) {
+          outlier_sentence <- if (info$outlier_count > 0) {
+            sprintf(
+              "%d multivariate outlier%s flagged.",
+              info$outlier_count,
+              ifelse(info$outlier_count == 1, "", "s")
+            )
+          } else {
+            "No multivariate outliers were flagged."
+          }
+          details <- c(
+            details,
+            sprintf("Outlier method: %s. %s", info$outlier_label, outlier_sentence)
+          )
+        }
+        if (isTRUE(info$cleaned_available)) {
+          details <- c(
+            details,
+            "A cleaned dataset excluding flagged outliers is available in the Cleaned data tab."
           )
         }
 
-        if (isTRUE(is.finite(p_val))) {
-          detail <- paste("Reported p-value:", formatC(p_val, digits = 3, format = "g"))
-          alert_class <- if (p_val < alpha) "alert-warning" else "alert-success"
-          shiny::div(class = paste("alert", alert_class), base_message, detail)
+        if (!is.null(info$p_value) && is.finite(info$p_value)) {
+          details <- c(details, sprintf("Reported p-value: %s.", info$p_display))
+          alert_class <- if (info$p_value < info$alpha) {
+            "alert alert-warning"
+          } else {
+            "alert alert-success"
+          }
         } else {
-          shiny::div(class = "alert alert-info", base_message, "Review the table below for details.")
+          details <- c(details, "Reported p-value is unavailable. Review the tables below for additional details.")
+          alert_class <- "alert alert-info"
         }
+
+        detail_tags <- lapply(details, shiny::tags$p)
+        shiny::div(
+          class = alert_class,
+          shiny::tags$p(base_text),
+          detail_tags
+        )
       })
 
-      output$test_table <- shiny::renderTable({
+      render_results_table <- function(data) {
+        DT::datatable(
+          data,
+          options = list(
+            pageLength = 10,
+            scrollX = TRUE,
+            lengthMenu = c(5, 10, 25, 50, 100)
+          ),
+          rownames = FALSE,
+          filter = "top",
+          class = "display nowrap"
+        )
+      }
+
+      output$multivariate_table <- DT::renderDataTable({
         res <- analysis_result()
         shiny::req(res)
         tbl <- res$multivariate_normality
-        shiny::req(tbl)
-        as.data.frame(tbl)
-      }, rownames = FALSE)
+        shiny::validate(shiny::need(!is.null(tbl), "Multivariate test results are unavailable."))
+        render_results_table(as.data.frame(tbl))
+      })
 
-      output$descriptives_table <- shiny::renderTable({
+      output$univariate_table <- DT::renderDataTable({
+        res <- analysis_result()
+        shiny::req(res)
+        tbl <- res$univariate_normality
+        shiny::validate(shiny::need(!is.null(tbl), "Univariate test results are unavailable."))
+        render_results_table(as.data.frame(tbl))
+      })
+
+      output$descriptives_table <- DT::renderDataTable({
         res <- analysis_result()
         opts <- settings()
         shiny::req(res, opts)
@@ -224,9 +412,33 @@ mod_results_server <- function(id, processed_data, settings, analysis_data = NUL
           shiny::validate(shiny::need(FALSE, "Enable descriptive statistics in the Analysis Settings tab to view this table."))
         }
         tbl <- res$descriptives
-        shiny::req(tbl)
-        utils::head(as.data.frame(tbl), n = 12)
-      }, rownames = FALSE)
+        shiny::validate(shiny::need(!is.null(tbl), "Descriptive statistics were not returned."))
+        render_results_table(as.data.frame(tbl))
+      })
+
+      output$outliers_table <- DT::renderDataTable({
+        res <- analysis_result()
+        shiny::req(res)
+        tbl <- res$multivariate_outliers
+        if (is.null(tbl)) {
+          shiny::validate(shiny::need(FALSE, "No multivariate outliers were detected."))
+        }
+        df <- as.data.frame(tbl)
+        if (!nrow(df)) {
+          shiny::validate(shiny::need(FALSE, "No multivariate outliers were detected."))
+        }
+        render_results_table(df)
+      })
+
+      output$clean_data_table <- DT::renderDataTable({
+        res <- analysis_result()
+        shiny::req(res)
+        tbl <- res$new_data
+        if (is.null(tbl)) {
+          shiny::validate(shiny::need(FALSE, "Cleaned dataset is generated when multivariate outliers are removed."))
+        }
+        render_results_table(as.data.frame(tbl))
+      })
 
       output$analysis_summary <- shiny::renderPrint({
         res <- analysis_result()


### PR DESCRIPTION
## Summary
- add summary cards and DT-based tables for multivariate, univariate, descriptive, outlier, and cleaned data outputs in the Results tab
- expand the report/export module with CSV/YAML/JSON downloads and richer analysis context
- declare supporting dependencies for DT-driven tables and parameter serialization

## Testing
- not run (Rscript unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1205d3cf0832abdf0d1ef16ac889a