### PR TITLE
Link Run analysis button with results computations

### DIFF
--- a/mvn-shiny-app/app_server.R
+++ b/mvn-shiny-app/app_server.R
@@ -10,6 +10,7 @@ app_server <- function(input, output, session) {
     "results",
     processed_data = data_prep$processed_data,
     settings = analysis_settings$settings,
+    run_analysis = analysis_settings$run_analysis,
     analysis_data = data_prep$analysis_data,
     subset = data_prep$subset
   )

--- a/mvn-shiny-app/modules/mod_analysis_settings.R
+++ b/mvn-shiny-app/modules/mod_analysis_settings.R
@@ -70,7 +70,7 @@ mod_analysis_settings_ui <- function(id) {
         shiny::helpText("Energy test always uses bootstrap replicates. Adjust settings to control computation time.")
       ),
       shiny::numericInput(ns("alpha"), label = "Significance level (alpha)", value = 0.05, min = 0.0001, max = 0.25, step = 0.01),
-      shiny::actionButton(ns("apply_settings"), label = "Run analysis", class = "btn-primary")
+      shiny::actionButton(ns("run_analysis"), label = "Run analysis", class = "btn-primary")
     ),
     bslib::layout_column_wrap(
       width = 1,
@@ -171,10 +171,15 @@ mod_analysis_settings_server <- function(id, processed_data = NULL) {
       }
 
       settings <- shiny::eventReactive(
-        input$apply_settings,
+        input$run_analysis,
         collect_settings(),
         ignoreNULL = FALSE
       )
+
+      run_counter <- shiny::reactiveVal(0L)
+      observeEvent(input$run_analysis, {
+        run_counter(run_counter() + 1L)
+      }, ignoreNULL = FALSE)
 
       data_dims <- shiny::reactive({
         if (is.null(processed_data)) {
@@ -234,7 +239,10 @@ mod_analysis_settings_server <- function(id, processed_data = NULL) {
         cat("Alpha:", format(opts$alpha, digits = 3), "\n")
       })
 
-      list(settings = settings)
+      list(
+        settings = settings,
+        run_analysis = shiny::reactive(run_counter())
+      )
     }
   )
 }

--- a/mvn-shiny-app/modules/mod_results.R
+++ b/mvn-shiny-app/modules/mod_results.R
@@ -48,8 +48,11 @@ mod_results_ui <- function(id) {
   )
 }
 
-mod_results_server <- function(id, processed_data, settings, analysis_data = NULL, subset = NULL) {
+mod_results_server <- function(id, processed_data, settings, run_analysis = NULL, analysis_data = NULL, subset = NULL) {
   stopifnot(is.function(processed_data), is.function(settings))
+  if (!is.null(run_analysis)) {
+    stopifnot(is.function(run_analysis))
+  }
   data_for_analysis <- if (is.null(analysis_data)) processed_data else analysis_data
   stopifnot(is.function(data_for_analysis))
   subset_var <- if (is.null(subset)) {
@@ -182,7 +185,9 @@ mod_results_server <- function(id, processed_data, settings, analysis_data = NUL
         invisible(NULL)
       }
 
-      observeEvent(settings(), {
+      analysis_trigger <- if (is.null(run_analysis)) settings else run_analysis
+
+      observeEvent(analysis_trigger(), {
         opts <- settings()
         df <- data_for_analysis()
         if (is.null(df) || is.null(opts)) {


### PR DESCRIPTION
## Summary
- rename the Analysis Settings action button to `run_analysis` and expose a reactive trigger when it is pressed
- update the results module so it can listen for the new trigger and rerun the MVN analysis when the button is clicked
- thread the trigger through `app_server()` so the Results tab updates immediately after each Run analysis request

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1319dae98832a8e9c897ccc861a5b