### PR TITLE
Fix reactivity for analysis execution trigger

### DIFF
--- a/mvn-shiny-app/modules/mod_analysis_settings.R
+++ b/mvn-shiny-app/modules/mod_analysis_settings.R
@@ -176,10 +176,10 @@ mod_analysis_settings_server <- function(id, processed_data = NULL) {
         ignoreNULL = FALSE
       )
 
-      run_counter <- shiny::reactiveVal(0L)
-      observeEvent(input$run_analysis, {
-        run_counter(run_counter() + 1L)
-      }, ignoreNULL = FALSE)
+      run_trigger <- shiny::reactive({
+        count <- input$run_analysis
+        if (is.null(count)) 0L else as.integer(count)
+      })
 
       data_dims <- shiny::reactive({
         if (is.null(processed_data)) {
@@ -241,7 +241,7 @@ mod_analysis_settings_server <- function(id, processed_data = NULL) {
 
       list(
         settings = settings,
-        run_analysis = shiny::reactive(run_counter())
+        run_analysis = run_trigger
       )
     }
   )

--- a/mvn-shiny-app/modules/mod_results.R
+++ b/mvn-shiny-app/modules/mod_results.R
@@ -209,7 +209,14 @@ mod_results_server <- function(id, processed_data, settings, run_analysis = NULL
         invisible(NULL)
       }
 
-      analysis_trigger <- if (is.null(run_analysis)) settings else run_analysis
+      analysis_trigger <- shiny::reactive({
+        current_settings <- settings()
+        if (is.null(run_analysis)) {
+          list(settings = current_settings)
+        } else {
+          list(settings = current_settings, trigger = run_analysis())
+        }
+      })
 
       observeEvent(analysis_trigger(), {
         opts <- settings()


### PR DESCRIPTION
## Summary
- replace the analysis trigger counter with a reactive bound directly to the Run analysis button value
- update the results module to listen to both the Run analysis trigger and refreshed settings so downstream tabs refresh reliably

## Testing
- not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d13e1e66c0832ab44f3bf06a3cadac