### PR TITLE
Ensure MVN shiny subset column is retained

### DIFF
--- a/inst/mvn-shiny-app/modules/mod_results.R
+++ b/inst/mvn-shiny-app/modules/mod_results.R
@@ -498,9 +498,19 @@ mod_results_server <- function(id, processed_data, settings, run_analysis = NULL
 
       run_mvn_analysis <- function(prepared, opts) {
         df <- as.data.frame(prepared$data)
+        group <- prepared$group
+
+        # Ensure only the numeric variables (and optional grouping variable) are
+        # passed to the MVN::mvn() call. The grouping column must remain in the
+        # data so that the subset argument can be resolved correctly.
         numeric_cols <- names(df)[vapply(df, is.numeric, logical(1))]
-        df <- df[, numeric_cols, drop = FALSE]
-        
+        keep_cols <- if (is.null(group)) {
+          numeric_cols
+        } else {
+          unique(c(numeric_cols, group))
+        }
+        df <- df[, keep_cols, drop = FALSE]
+
         MVN::mvn(
           data = df,
           subset = prepared$group,


### PR DESCRIPTION
## Summary
- keep the selected grouping column when preparing data for MVN::mvn in the shiny module
- avoid dropping the subset column so MVN::mvn can resolve it correctly while still filtering to numeric variables

## Testing
- attempted to run `Rscript -e "devtools::load_all(); MVN::mvn(iris, subset='Species')"` *(fails: `Rscript` not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fce93fa4832ab087a1dda1b14a85