### PR TITLE
Remove graphs page and fix dropdown z-index

### DIFF
--- a/inst/mvn-shiny-app/app_server.R
+++ b/inst/mvn-shiny-app/app_server.R
@@ -15,11 +15,6 @@ app_server <- function(input, output, session) {
     subset = data_prep$subset
   )
 
-  mod_graphs_server(
-    "graphs",
-    processed_data = data_prep$processed_data
-  )
-
   mod_report_server(
     "report",
     processed_data = data_prep$processed_data,

--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -2,10 +2,29 @@ app_ui <- function(request) {
   bslib::page_navbar(
     title = "MVN Shiny App",
     theme = bslib::bs_theme(version = 5, bootswatch = "flatly"),
+    header = shiny::tags$head(
+      shiny::tags$style(
+        "
+        .selectize-control {
+          position: relative;
+          z-index: 2000 !important;
+        }
+
+        .selectize-dropdown,
+        .dropdown-menu {
+          z-index: 2001 !important;
+        }
+
+        .selectize-dropdown-content {
+          position: relative;
+          z-index: 2002 !important;
+        }
+        "
+      )
+    ),
     bslib::nav_panel("Data & Preprocessing", mod_data_prep_ui("data_prep")),
     bslib::nav_panel("Analysis Settings", mod_analysis_settings_ui("analysis")),
     bslib::nav_panel("Results", mod_results_ui("results")),
-    bslib::nav_panel("Graphs", mod_graphs_ui("graphs")),
     bslib::nav_panel("Report / Download", mod_report_ui("report"))
   )
 }


### PR DESCRIPTION
## Summary
- remove the graphs navigation tab and server module wiring
- add global CSS so dropdown menus and selectize controls overlay nearby content correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5302218dc832ab3e1ae8508b587ff