### PR TITLE
Add About tab to MVN Shiny app

### DIFF
--- a/inst/mvn-shiny-app/app_server.R
+++ b/inst/mvn-shiny-app/app_server.R
@@ -23,6 +23,8 @@ app_server <- function(input, output, session) {
     analysis_data = data_prep$analysis_data
   )
 
+  mod_about_server("about")
+
   observeEvent(data_prep$processed_data(), {
     prepared <- data_prep$processed_data()
     if (!is.null(prepared)) {

--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -41,6 +41,7 @@ app_ui <- function(request) {
     bslib::nav_panel("Data & Preprocessing", mod_data_prep_ui("data_prep")),
     bslib::nav_panel("Analysis Settings", mod_analysis_settings_ui("analysis")),
     bslib::nav_panel("Results", mod_results_ui("results")),
-    bslib::nav_panel("Report / Download", mod_report_ui("report"))
+    bslib::nav_panel("Report / Download", mod_report_ui("report")),
+    bslib::nav_panel("About", mod_about_ui("about"))
   )
 }

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -1,0 +1,64 @@
+mod_about_ui <- function(id) {
+  shiny::tagList(
+    bslib::layout_sidebar(
+      sidebar = bslib::sidebar(
+        shiny::h2("About MVN Shiny App"),
+        shiny::p(
+          "This interactive interface wraps the capabilities of the MVN R package,",
+          "allowing you to explore, diagnose, and report on the multivariate",
+          "normality of your data."
+        )
+      ),
+      bslib::layout_column_wrap(
+        width = NULL,
+        bslib::card(
+          bslib::card_body(
+            shiny::h3("Getting Started"),
+            shiny::p(
+              "Upload or select a dataset on the Data & Preprocessing tab to prepare",
+              "variables for analysis, then configure the statistical checks you",
+              "would like to run."
+            ),
+            shiny::p(
+              "Review computed measures and diagnostic plots in the Results tab,",
+              "and export a comprehensive PDF report from the Report / Download tab"
+            )
+          )
+        ),
+        bslib::card(
+          bslib::card_body(
+            shiny::h3("Recommended Citation"),
+            shiny::p(
+              "If you use this application or the MVN package in your work, please cite:",
+              shiny::tags$cite(
+                "Selcuk Korkmaz, Dincer Goksuluk, and Gokmen Zararsiz (2014).",
+                " MVN: An R Package for Assessing Multivariate Normality. The R Journal",
+                " 6(2), 151--162.",
+                " doi:10.32614/RJ-2014-031."
+              )
+            ),
+            shiny::tags$pre(
+              "@article{RJ-2014-031,\n",
+              "  author = {Selcuk Korkmaz and Dincer Goksuluk and Gokmen Zararsiz},\n",
+              "  title = {MVN: An R Package for Assessing Multivariate Normality},\n",
+              "  year = {2014},\n",
+              "  journal = {The R Journal},\n",
+              "  doi = {10.32614/RJ-2014-031},\n",
+              "  url = {https://doi.org/10.32614/RJ-2014-031},\n",
+              "  pages = {151--162},\n",
+              "  volume = {6},\n",
+              "  number = {2}\n",
+              "}"
+            )
+          )
+        )
+      )
+    )
+  )
+}
+
+mod_about_server <- function(id) {
+  shiny::moduleServer(id, function(input, output, session) {
+    invisible(NULL)
+  })
+}


### PR DESCRIPTION
## Summary
- add a dedicated About tab that introduces the MVN Shiny App and outlines basic usage steps
- provide recommended citation information, including a ready-to-copy BibTeX entry
- register the new module with the app UI and server

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db933c6680832a9aa297e0f024e03d