### PR TITLE
Ensure reliable ZIP downloads for analysis exports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Suggests:
     readxl,
     shiny,
     yaml,
-    promises
+    promises,
+    zip
 Collate:
     'mvn.R'
     'mardia.R'


### PR DESCRIPTION
## Summary
- add a reusable helper that validates ZIP archive creation and falls back between zip::zipr and utils::zip
- reuse the helper for exporting analysis tables and plots so incomplete archives raise a clear error
- suggest the zip package for reliable cross-platform archive support

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e660659ec4832ab03a7a598719c4ef