### PR TITLE
Add missing about module server function

### DIFF
--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -101,3 +101,12 @@ mod_about_ui <- function(id) {
     )
   )
 }
+
+mod_about_server <- function(id) {
+  shiny::moduleServer(
+    id,
+    function(input, output, session) {
+      invisible(NULL)
+    }
+  )
+}


### PR DESCRIPTION
## Summary
- add the missing `mod_about_server()` definition so the About tab module can be registered without errors

## Testing
- not run (Rscript not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e6641dba6c832aa3b1db1662cd988d