### PR TITLE
Ensure ZIP downloads specify content type

### DIFF
--- a/inst/mvn-shiny-app/modules/mod_report.R
+++ b/inst/mvn-shiny-app/modules/mod_report.R
@@ -632,7 +632,8 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
           res <- analysis_result()
           shiny::req(res)
           write_tables_archive(res, file)
-        }
+        },
+        contentType = "application/zip"
       )
 
       output$download_plots_zip <- shiny::downloadHandler(
@@ -644,7 +645,8 @@ mod_report_server <- function(id, processed_data, analysis_result, settings, ana
           opts <- settings()
           shiny::req(res, opts)
           write_plots_archive(res, opts, file)
-        }
+        },
+        contentType = "application/zip"
       )
     }
   )


### PR DESCRIPTION
## Summary
- set the download handlers for the tables and plots archives to serve application/zip content

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6670033cc832aaf8b2c57c88532a1