### PR TITLE
Fix Bootswatch theme preset for Bootstrap 5

### DIFF
--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -1,7 +1,10 @@
 app_ui <- function(request) {
   bslib::page_navbar(
     title = "MVN Shiny App",
-    theme = bslib::bs_theme(version = 5, bootswatch = "flatly"),
+    theme = bslib::bs_theme(
+      version = 5,
+      preset = bslib::preset_bootswatch("flatly")
+    ),
     header = shiny::tags$head(
       shiny::tags$style(
         "

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -5,7 +5,7 @@ mod_about_ui <- function(id) {
         version = 5,
         base_font = bslib::font_google("Inter"),
         heading_font = bslib::font_google("Inter"),
-        bootswatch = "flatly"
+        preset = bslib::preset_bootswatch("flatly")
       ),
       shiny::fluidRow(
         shiny::column(


### PR DESCRIPTION
## Summary
- replace deprecated Bootswatch argument with preset helper to support Bootstrap 5 themes
- ensure the main UI and About module both use the resolved Flatly preset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7b8cdbc88832a89d90ea81a7bbf8f