### PR TITLE
Fix bslib BootsWatch preset usage

### DIFF
--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -3,7 +3,7 @@ app_ui <- function(request) {
     title = "MVN Shiny App",
     theme = bslib::bs_theme(
       version = 5,
-      preset = bslib::preset_bootswatch("flatly")
+      bootswatch = "flatly"
     ),
     header = shiny::tags$head(
       shiny::tags$style(

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -5,7 +5,7 @@ mod_about_ui <- function(id) {
         version = 5,
         base_font = bslib::font_google("Inter"),
         heading_font = bslib::font_google("Inter"),
-        preset = bslib::preset_bootswatch("flatly")
+        bootswatch = "flatly"
       ),
       shiny::fluidRow(
         shiny::column(


### PR DESCRIPTION
## Summary
- replace preset_bootswatch() usage with the bootswatch argument to maintain compatibility with current bslib releases

## Testing
- R CMD check --no-manual --as-cran *(fails: R is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e7b9f55a54832ab16495cc7faf646e