### PR TITLE
Switch Shiny app Bootswatch theme to minty

### DIFF
--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -3,7 +3,7 @@ app_ui <- function(request) {
     title = "MVN Shiny App",
     theme = bslib::bs_theme(
       version = 5,
-      bootswatch = "flatly"
+      bootswatch = "minty"
     ),
     header = shiny::tags$head(
       shiny::tags$style(

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -5,7 +5,7 @@ mod_about_ui <- function(id) {
         version = 5,
         base_font = bslib::font_google("Inter"),
         heading_font = bslib::font_google("Inter"),
-        bootswatch = "flatly"
+        bootswatch = "minty"
       ),
       shiny::fluidRow(
         shiny::column(


### PR DESCRIPTION
## Summary
- replace the unsupported Bootstrap 5 Bootswatch preset with the minty theme in the main navbar page
- update the about module to use the same Bootstrap 5-compatible minty preset

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7baaa9f04832aafd3be63c594b12f