### PR TITLE
Fix Bootswatch theme preset error

### DIFF
--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -3,7 +3,7 @@ app_ui <- function(request) {
     title = "MVN Shiny App",
     theme = bslib::bs_theme(
       version = 5,
-      bootswatch = "minty"
+      bootswatch = "flatly"
     ),
     header = shiny::tags$head(
       shiny::tags$style(

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -5,7 +5,7 @@ mod_about_ui <- function(id) {
         version = 5,
         base_font = bslib::font_google("Inter"),
         heading_font = bslib::font_google("Inter"),
-        bootswatch = "minty"
+        bootswatch = "flatly"
       ),
       shiny::fluidRow(
         shiny::column(


### PR DESCRIPTION
## Summary
- replace the unsupported Bootswatch "minty" preset with the Bootstrap 5-compatible "flatly" theme in the Shiny UI components

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7bb5e2740832aa023f92ae60107c8