### PR TITLE
Define custom Bootstrap 5 theme without Bootswatch preset

### DIFF
--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -3,7 +3,12 @@ app_ui <- function(request) {
     title = "MVN Shiny App",
     theme = bslib::bs_theme(
       version = 5,
-      bootswatch = "minty"
+      bg = "#ecf0f1",
+      fg = "#2c3e50",
+      primary = "#18bc9c",
+      secondary = "#2c3e50",
+      base_font = bslib::font_google("Inter"),
+      heading_font = bslib::font_google("Inter")
     ),
     header = shiny::tags$head(
       shiny::tags$style(

--- a/inst/mvn-shiny-app/modules/mod_about.R
+++ b/inst/mvn-shiny-app/modules/mod_about.R
@@ -3,9 +3,12 @@ mod_about_ui <- function(id) {
     shiny::fluidPage(
       theme = bslib::bs_theme(
         version = 5,
+        bg = "#ecf0f1",
+        fg = "#2c3e50",
+        primary = "#18bc9c",
+        secondary = "#2c3e50",
         base_font = bslib::font_google("Inter"),
-        heading_font = bslib::font_google("Inter"),
-        bootswatch = "minty"
+        heading_font = bslib::font_google("Inter")
       ),
       shiny::fluidRow(
         shiny::column(


### PR DESCRIPTION
## Summary
- replace the unsupported Bootswatch preset with a custom Bootstrap 5 color palette for the main UI
- apply the same palette to the About page module to keep styling consistent without preset lookups

## Testing
- not run (R runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e7bb5e2740832aa023f92ae60107c8