### PR TITLE
Navigate to results after running analysis

### DIFF
--- a/inst/mvn-shiny-app/app_server.R
+++ b/inst/mvn-shiny-app/app_server.R
@@ -25,6 +25,11 @@ app_server <- function(input, output, session) {
 
   mod_about_server("about")
 
+  shiny::observeEvent(analysis_settings$run_analysis(), {
+    shiny::req(analysis_settings$run_analysis() > 0)
+    bslib::nav_select(id = "main_nav", selected = "Results")
+  }, ignoreNULL = TRUE)
+
   observeEvent(data_prep$processed_data(), {
     prepared <- data_prep$processed_data()
     if (!is.null(prepared)) {

--- a/inst/mvn-shiny-app/app_ui.R
+++ b/inst/mvn-shiny-app/app_ui.R
@@ -1,5 +1,6 @@
 app_ui <- function(request) {
   bslib::page_navbar(
+    id = "main_nav",
     title = "MVN Shiny App",
     theme = bslib::bs_theme(
       version = 5,


### PR DESCRIPTION
## Summary
- assign an id to the main navigation bar so it can be updated programmatically
- automatically switch to the Results tab whenever the analysis is run

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8bbfc1520832a96850829a6ca8c5d